### PR TITLE
feat: migrate internal subskills to read-direct pattern

### DIFF
--- a/cali-product-workflow-spec.md
+++ b/cali-product-workflow-spec.md
@@ -68,7 +68,7 @@ Phase 8:  Interface Brainstorm → 5 ASCII proposals + hybrid
 Phase 9:  Interface Gate    → Plannotator visual approval
 Phase 10: Interface Selection → User picks via ask_user_question
 Phase 11: Tech Planning     → Typed scopes (feature/spike/optimize)
-Phase 12: Execution         → Automatic via /sisyphus or autoresearch
+Phase 12: Execution         → Automatic via ordered-execution-goal or autoresearch
 Phase 13: Delivery Audit    → Post-execution verification
 ```
 
@@ -167,10 +167,10 @@ Phase 13: Delivery Audit    → Post-execution verification
 
 | Type | Executor | Use Case |
 |------|----------|----------|
-| `feature` | `/sisyphus` + `/supervise` | Standard features |
+| `feature` | **ordered-execution-goal** (see goals.md) + `/supervise` | Standard features |
 | `optimization` | `autoresearch-create` | Performance tuning |
-| `spike` | `/sisyphus` + `/supervise` | Research/uncertainty |
-| `test-*` | `/sisyphus` + testing gates | Test coverage |
+| `spike` | **ordered-execution-goal** (see goals.md) + `/supervise` | Research/uncertainty |
+| `test-*` | **ordered-execution-goal** (see goals.md) + testing gates | Test coverage |
 
 **Rules:**
 - Sequencing: Riskiest-first or UI-first principle
@@ -290,10 +290,10 @@ Worktree Check ───► [Create git worktree if needed]
     ▼
 For each scope (in sequence):
     │
-    ├── TYPE=feature ──► /sisyphus + /supervise
+    ├── TYPE=feature ──► ordered-execution-goal + /supervise
     ├── TYPE=optimization ──► /autoresearch-create
-    ├── TYPE=spike ──► /sisyphus + /supervise
-    └── TYPE=test-* ──► /sisyphus + testing gates
+    ├── TYPE=spike ──► ordered-execution-goal + /supervise
+    └── TYPE=test-* ──► ordered-execution-goal + testing gates
     │
     ▼
 Code Quality Gate (optional)
@@ -469,7 +469,7 @@ Code Quality Gate (optional)
 | hasCommands | boolean | Supports slash commands |
 | hasSubagent | boolean | Subagent delegation |
 | hasAskUserQuestion | boolean | ask_user_question tool |
-| hasGoals | boolean | /goals integration |
+| hasGoals | boolean | Goal system (ordered/flexible modes) |
 | hasIntercom | boolean | Cross-session messaging |
 | hasSupervise | boolean | Supervisor tracking |
 | hasTUI | boolean | UI overlay |

--- a/docs/TOOL-REFERENCE-PATTERN.md
+++ b/docs/TOOL-REFERENCE-PATTERN.md
@@ -22,7 +22,7 @@ cali-product-workflow/
 │   └── cli-tools/
 │       ├── ask.md           # Tool: ask_user_question
 │       ├── subagents.md     # Tool: subagent
-│       ├── goals.md         # Tool: /sisyphus, /goal
+│       ├── goals.md         # Tool: Goal System (ordered/flexible modes)
 │       ├── plannotator.md   # Tool: plannotator
 │       ├── phase-status.md  # Tool: /pw-*
 │       ├── safe-change.md   # Tool: safe-change

--- a/docs/investigacao-mobile-adaptativo.md
+++ b/docs/investigacao-mobile-adaptativo.md
@@ -1,0 +1,105 @@
+# Investigação — Sessão Mobile Adaptativo e Melhorias
+
+## 1. Sisyphus nos arquivos do projeto
+
+**Localização:**
+- `skills/cali-product-workflow/references/cli-tools/goals.md` — documentação principal
+- `extensions/cali-product-workflow/state.ts:157` — mapeamento `goals: "goal/sisyphus"`
+- `skills/cali-product-workflow/phases/execution.md` — tabelas de routing
+
+**Resumo:**
+- `/sisyphus` é usado para scopes: `feature`, `spike`, `test-*`
+- `/autoresearch-create` para `optimization`
+- O documento especifica que **não se deve perguntar** "Create /sisyphus?" — execução é automática após Tech Planning
+
+---
+
+## 2. Perguntas com >4 opções vs ask_user_question
+
+**Documentado em `ask-patterns.md:23`:**
+```
+`ask_user_question` supports:
+- **2-6 options** per question (MAX_OPTIONS = 6)
+```
+
+**Problema real:**
+Na sessão mobile-adaptativo houve `validation failed: "questions.0.options: must have at most 4 items"`.
+
+**Hipótese:** A sessão estava usando uma versão mais antiga da skill ou da CLI que tinha limite de 4. A skill `ask-patterns.md` já foi atualizada para 6, mas pode haver desatualização em cascata.
+
+**Regra a implementar:**
+1. Antes de usar `ask_user_question`, verificar o limite de options
+2. Se >4 para single-select com 5+ opções necessárias:
+   - **Opção A (Interface Brainstorming):** Mostrar as 5 geradas + 1 híbrida criada depois
+   - **Opção B (Strategic approaches):** Dividir em 2 etapas sequenciais, cada uma com 3-4 opções
+3. Se multi-select: perguntar primeiro "Quais domínios?" depois "Quais abordagens?"
+
+---
+
+## 3. Footer de fases não atualizado — Hipótese D
+
+**Código encontrado:**
+- `extensions/cali-product-workflow/ui.ts:129-137` — `notifyPhase()` atualiza via TUI
+- `extensions/cali-product-workflow/index.ts:112` — `updateFooter(ctx, wd)` chamado em hooks
+
+**O que deveria acontecer:**
+1. Usuário chama `/skill:cali-product-workflow`
+2. Hook `onUserMessage` detecta e cria workflow com `currentPhase: 0`
+3. Hook `updateFooter()` é chamado para mostrar `Triage (1/11)`
+4. Quando fase avança, `notifyPhase()` mostra notificação
+
+**Hipótese para falha:**
+
+| # | Hipótese | evidência | Verificação |
+|---|----------|-----------|-------------|
+| H1 | Extensão não carregou na sessão mobile | A skill foi chamada via `/skill`, não via hook | Verificar se extensão está ativa |
+| H2 | Hook não executou updateFooter | Apenas skill carregou, extensão não | O TUI pode estar em modo "skill only" |
+| H3 | Session mode diferente | worktree-checkouts é um ambiente isolado | Verificar se hooks funcionam em worktrees |
+| H4 | Goal system interferiu | pi-goal-state pode ter sobrescrito workflow state | Verificar ordem de eventos |
+
+**Verificação necessária:**
+```bash
+# Verificar se extensão carrega em worktree
+cd /Users/cali/Library/Application\ Support/Muxy/worktree-checkouts/52A56F1F-DB92-452E-AB09-D94772CD03E5/mobile-adaptative
+pi --version
+# Tentar iniciar workflow e verificar footer
+```
+
+**Melhoria potencial:**
+Adicionar no hook de mensagem um check: se `pi-goal-state` existe E workflow está ativo, sincronizar ambos os estados (goal vs workflow phases).
+
+---
+
+## 4. Resumo — Melhorias reais (não cosméticas)
+
+| # | Melhoria | Justificativa | Arquivo a alterar |
+|---|----------|---------------|-------------------|
+| 1 | **Verificar limite de options antes de chamar ask** | Evitar validation failed e refazer pergunta | `phases/ask-patterns.md` |
+| 2 | **Fallback para chat quando tool não suporta** | Manter fluxo quando tool falha | `skills/cali-product-workflow/SKILL.md` |
+| 3 | **Dividir perguntas >4 em etapas** | Interface Brainstorming com 5+1 híbrido | `phases/ask-patterns.md` |
+| 4 | **Sincronizar goal state + workflow phase** | Evitar estados inconsistentes entre systems | `extensions/cali-product-workflow/index.ts` |
+| 5 | **Resumir subagent failure e continuar de onde parou** | Não avançar fase quando subagent falha | `skills/cali-product-workflow/phases/execution.md` |
+| 6 | **Confirmar Plannotator gate antes de prosseguir** | Evitar bypass de gate visual | `references/cli-tools/plannotator.md` |
+
+---
+
+## 5. Comportamento esperado vs real
+
+| Fase | Esperado | Real | Problema |
+|------|----------|------|----------|
+| 0-triage | Auto-detectado | ✅ OK | — |
+| 1-setup | Auto-iniciado | ✅ OK | — |
+| 2-shape | Subagent cali-shape-up | ⚠️ Falhou (402) | Não tentou re-skill |
+| 3-strategy | Pergunta com 5 opções | ❌ Validation failed | Tool limit 4 vs skill 5 |
+| 4-critique | Plannotator --gate | ⚠️ Timeout | Não aguardou confirmação |
+| 5-scope | Plan批准 | ⚠️ Pulou gate | Bypass implícito |
+| 6-interface | (opcional) | ❌ Não chamado | Skipped |
+| 7-int-gate | Plannotator --gate | ⚠️ Timeout | Pulou ou bypassou |
+| 8-selection | ask_user_question | ✅ OK | — |
+| 9-tech-planning | Especificação técnica | ✅ OK | — |
+| 10-execution | Sisyphus goal | ✅ OK | — |
+| Footer fases | Mostrar N/11 | ❌ Não mostrado | Hook/extensão não funcionou |
+
+---
+
+*Gerado em 2026-05-22*

--- a/docs/investigacao-resumo-habilidades.md
+++ b/docs/investigacao-resumo-habilidades.md
@@ -1,0 +1,197 @@
+# Investigação — Sessão Mobile Adaptativo (2026-05-22)
+
+**Objetivo:** Investigar falhas no workflow de product-workflow durante sessão em worktree, documentar hipóteses e propor soluções.
+
+---
+
+## Contexto da Sessão
+
+**Sessão:** `/Users/cali/.pi/agent/sessions/--Users-cali-Library-Application Support-Muxy-worktree-checkouts-52A56F1F-DB92-452E-AB09-D94772CD03E5-mobile-adaptative--/2026-05-22T20-28-50-679Z_019e5160-5e77-7025-8b60-5ace4d955520.jsonl`
+
+**O que aconteceu:**
+1. Usuário chamou `/skill:cali-product-workflow` → "quero fazer o sistema funcionar em tela"
+2. Workflow executou 11 fases
+3. Goal criado via ordered-execution-goal (sistema automático)
+4. Goal completado, auditor aprovou (2ª tentativa)
+
+---
+
+## Problemas Identificados
+
+### P1: Footer de fases não apareceu
+
+**O que deveria acontecer:**
+- TUI do pi mostrar `[pw] workflow-name  │  ◆ Phase N/11`
+- Extensão `cali-product-workflow` atualizar footer via `updateFooter()` e `notifyPhase()`
+
+**O que aconteceu:**
+- Nenhuma fase visível no footer durante execução
+
+**Hipóteses:**
+
+| # | Hipótese | Probabilidade | evidência |
+|---|----------|---------------|-----------|
+| H1 | Extensão não carregou | Alta | Extension auto-discovered de `~/.pi/agent/extensions/` ou `.pi/extensions/`, mas skill está em `~/.agents/skills/` |
+| H2 | Hook não executou em worktree | Alta | worktree pode isolar eventos de extensão |
+| H3 | `pi-goal-state` sobrescreveu `workflow-state` | Média | Goal foi criado ANTES da extensão atualizar footer |
+| H4 | `currentPhase` não sincronizou com TUI | Média | Código em `ui.ts:129-137` pode não ter sido chamado |
+
+**Verificação necessária:**
+```bash
+# 1. Verificar se extensão existe no path correto
+ls ~/.pi/agent/extensions/
+
+# 2. Verificar se extensão carregou em worktree
+cd /Users/cali/Library/Application\ Support/Muxy/worktree-checkouts/52A56F1F-DB92-452E-AB09-D94772CD03E5/mobile-adaptative
+pi --version
+
+# 3. Iniciar workflow e verificar footer
+pi /skill:cali-product-workflow
+# observar se footer mostra fases
+```
+
+**Solução proposta:**
+1. Criar `~/.pi/agent/extensions/cali-product-workflow/` (symlink ou copy)
+2. Adicionar no hook de mensagem sync entre `pi-goal-state` e `workflow-phase`
+3. Testar em worktree para validar
+
+---
+
+### P2: Sisyphus usado onde não deveria perguntar
+
+**O que está documentado:**
+- `goals.md`: "DO NOT ask 'Create ordered-execution-goal?' — execução automática após Tech Planning"
+- Mas na prática o sistema criou goal via `/sisyphus` (com discussão implícita)
+
+**Do README do pi-goal:**
+```
+/sisyphus <topic>       Discuss/grill a Sisyphus-style goal, then confirm a draft
+/sisyphus-set <objective> Immediately create and start a Sisyphus-style goal
+```
+
+**Contexto do workflow:**
+- Após Tech Planning, o plano já está aprovado
+- **Não deveria haver discussão adicional**
+- Deveria usar `/sisyphus-set` para iniciar imediatamente
+
+**Hipótese:**
+- O workflow usou `/sisyphus` (com confirmação) ao invés de `/sisyphus-set` (sem confirmação)
+- Isso pode ter causado delay desnecessário
+
+**Solução proposta:**
+1. Atualizar `skills/cali-product-workflow/phases/execution.md`:
+   - Trocar `/sisyphus` → `/sisyphus-set`
+   - Adicionar nota: "Use sisyphus-set para execução automática após Tech Planning"
+2. Atualizar `goals.md`: mesma alteração
+
+---
+
+### P3: Pergunta com 5 opções deu validation failed
+
+**O que aconteceu:**
+- Sessão tentou usar `ask_user_question` com 5 opções para Strategic Exploration (Phase 2)
+- Erro: `"questions.0.options: must have at most 4 items"`
+- Agente reduziu para 4, mas informação pode ter sido perdida
+
+**Documentado em `ask-patterns.md:23`:**
+```
+`ask_user_question` supports:
+- **2-6 options** per question (MAX_OPTIONS = 6)
+```
+
+**Hipótese:**
+- A versão da CLI na sessão tinha limite de 4 opções
+- A skill atualizada para 6, mas CLI desatualizada
+
+**Alternativa para Future:**
+Se tool não permite N opções:
+1. **Single-select (>4):** Dividir em 2 perguntas sequenciais
+2. **Multi-select (>4):** Duas etapas (domínio + abordagem)
+
+**Regra a implementar em `ask-patterns.md`:**
+```markdown
+## Limite de Options
+
+Antes de chamar `ask_user_question`:
+1. Verificar se N opções é suportado
+2. Se validation failed:
+   - Single-select >4: dividir em 2 perguntas
+   - Multi-select >4: "Quais domínios?" depois "Quais abordagens?"
+
+Para Interface Brainstorming (5 + 1 híbrido):
+- Etapa 1: mostrar 5 geradas
+- Etapa 2: criar híbrida baseada nas escolhidas
+```
+
+---
+
+### P4: Subagent cali-shape-up falhou (402)
+
+**O que aconteceu:**
+- Sessão tentou usar `subagent({ agent: "cali-shape-up" })`
+- Erro: `402` (budget esgotado)
+- Agente fez fallback manual
+
+**Hipótese:**
+- Subagent tentou usar modelo sem budget disponível
+- Agente root tinha budget diferente e executou manualmente
+
+**Problema adicional:**
+- Subagent procurar skill em `~/.agents/skills/` por default
+- Mas `cali-shape-up` está em `~/.agents/skills/cali-product-workflow/skills-workflow/`
+
+**Por que não encontrou?**
+Do docs de skills:
+> "Skill name collision resolution is based on arbitrary scan order"
+
+O subagent pode ter procurado errado path ou usado versão desatualizada.
+
+**Soluções:**
+1. Usar `/skill:cali-shape-up` (ativa skill diretamente, não subagent)
+2. Especificar path completo: `subagent({ skill: "cali-product-workflow/cali-shape-up" })`
+3. Adicionar fallback no workflow: se subagent falhar, executar fase manualmente
+
+---
+
+## Resumo — Ações Prioritárias
+
+| # | Prioridade | Ação | Arquivo |
+|---|------------|------|---------|
+| 1 | Alta | Criar symlink extensão em `~/.pi/agent/extensions/` | Setup |
+| 2 | Alta | Testar extensão em worktree (verificar footer) | Test |
+| 3 | Alta | Trocar ordered-discussion-goal → ordered-execution-goal na execução | `execution.md`, `goals.md` |
+| 4 | Média | Adicionar sync entre `pi-goal-state` e `workflow-phase` | `index.ts` |
+| 5 | Média | Adicionar regra de fallback para `ask_user_question` | `ask-patterns.md` |
+| 6 | Baixa | Documentar path de skills para subagent | `execution.md` |
+
+---
+
+## Comandos de Verificação
+
+```bash
+# Verificar extensão
+ls ~/.pi/agent/extensions/
+
+# Verificar skills
+ls ~/.agents/skills/cali-product-workflow/skills-workflow/
+
+# Testar workflow em worktree (criar nova sessão)
+cd /Users/cali/Library/Application\ Support/Muxy/worktree-checkouts/52A56F1F-DB92-452E-AB09-D94772CD03E5/mobile-adaptative
+pi /skill:cali-product-workflow
+# observer footer
+```
+
+---
+
+## Referências
+
+- **Sessão completa:** `/Users/cali/.pi/agent/sessions/...mobile-adaptativo...jsonl`
+- **pi-goal README:** `/tmp/pi-github-repos/capyup/pi-goal/README.md`
+- **Documentação extensão:** `extensions/cali-product-workflow/`
+- **Skills docs:** `skills/cali-product-workflow/`
+- **Ask patterns:** `phases/ask-patterns.md`
+
+---
+
+*Documento para double-check por outra LLM*  
+*Gerado: 2026-05-22*

--- a/docs/plano-migracao-skills-read-direct.md
+++ b/docs/plano-migracao-skills-read-direct.md
@@ -1,0 +1,253 @@
+# Plano: Migrar Skills para Leitura Direta (Opção B)
+
+**Data:** 2026-05-23
+**Estratégia:** Ler SKILL.md diretamente em vez de usar `/skill:` para subskills
+
+---
+
+## 1. MAPEAMENTO COMPLETO DE REFERÊNCIAS
+
+### 1.1 Referências ao Orchestrator (cali-product-workflow)
+
+**Mantém `/skill:cali-product-workflow`** — É a skill root, fica no lugar certo.
+
+| Arquivo | Linha | Contexto | Ação |
+|---------|-------|----------|------|
+| `extensions/cali-product-workflow/start.ts` | 192 | `"/skill:cali-product-workflow"` | ✅ Manter |
+| `extensions/cali-product-workflow/start.ts` | 201 | `pi.sendUserMessage("/skill:cali-product-workflow\n\n...")` | ✅ Manter |
+| `extensions/cali-product-workflow/commands.ts` | 282 | `pi.sendUserMessage("/skill:cali-product-workflow\n\n...")` | ✅ Manter |
+| `extensions/cali-product-workflow/commands.ts` | 962 | `"/skill:cali-product-workflow"` (doc) | ✅ Manter |
+| `extensions/cali-product-workflow/adapters/commands/dispatcher.ts` | 229 | `"/skill:cali-product-workflow"` (doc) | ✅ Manter |
+| `scripts/init-workflow.sh` | 30 | `echo "Run /skill:cali-product-workflow to start"` | ✅ Manter |
+| `scripts/setup.sh` | 76 | `echo "Use: /skill:cali-product-workflow"` | ✅ Manter |
+| `tests/README.md` | 230 | `when('/skill:cali-product-workflow', [...])` | ✅ Manter |
+
+---
+
+### 1.2 Referências às Subskills (skills-workflow)
+
+**MUDAR para leitura direta via `read()`**
+
+| Skill | Arquivo | Linha | Referência Atual | Novo Formato |
+|-------|---------|-------|------------------|--------------|
+| **cali-shape-up** | `SKILL.md` (orchestrator) | 9 | `/skill:cali-shape-up` | `read("skills-workflow/cali-shape-up/SKILL.md")` |
+| **cali-shape-up** | `SKILL.md` (orchestrator) | 111 | `delegate to subskills via /skill:` | `read("skills-workflow/{name}/SKILL.md")` |
+| **cali-shape-up** | `cali-shape-up/SKILL.md` | 17 | `1. Standalone: /skill:cali-shape-up` | Atualizar doc para `read()` |
+| **cali-plan-critique** | `SKILL.md` (orchestrator) | 11 | `/skill:cali-plan-critique` | `read("skills-workflow/cali-plan-critique/SKILL.md")` |
+| **cali-plan-critique** | `cali-plan-critique/SKILL.md` | 14 | `1. Standalone: /skill:cali-plan-critique` | Atualizar doc |
+| **cali-interface-brainstorm** | `SKILL.md` (orchestrator) | 10 | `/skill:cali-interface-brainstorm` | `read("skills-workflow/cali-interface-brainstorm/SKILL.md")` |
+| **cali-interface-brainstorm** | `cali-interface-brainstorm/SKILL.md` | 16 | `1. Standalone: /skill:cali-interface-brainstorm` | Atualizar doc |
+| **cali-tech-planning** | `SKILL.md` (orchestrator) | 12 | `/skill:cali-tech-planning` | `read("skills-workflow/cali-tech-planning/SKILL.md")` |
+| **cali-tech-planning** | `cali-tech-planning/SKILL.md` | 15 | `1. Standalone: /skill:cali-tech-planning` | Atualizar doc |
+
+---
+
+### 1.3 Referências às Execution Skills
+
+**MUDAR para leitura direta**
+
+| Skill | Arquivo | Linha | Referência Atual | Novo Formato |
+|-------|---------|-------|------------------|--------------|
+| **cali-testing-ai-code** | `SKILL.md` (orchestrator) | 13, 218 | `/skill:cali-testing-ai-code` | `read("skills-execution/cali-testing-ai-code/SKILL.md")` |
+| **cali-product-scope-executor** | `SKILL.md` (orchestrator) | 229, 233 | `/skill:cali-product-scope-executor` | `read("skills-execution/cali-product-scope-executor/SKILL.md")` |
+| **cali-product-scope-executor** | `phases/execution.md` | 148, 155 | `/skill:cali-product-scope-executor` | `read("skills-execution/cali-product-scope-executor/SKILL.md")` |
+| **cali-product-scope-executor** | `skills-execution/cali-product-scope-executor/SKILL.md` | 327, 336 | `/skill:cali-scope-executor` | Atualizar doc |
+
+---
+
+### 1.4 Referências a External Skills (autoresearch-create)
+
+**MANTER `/skill:autoresearch-create`** — É uma skill externa, não está no nosso package.
+
+| Arquivo | Linha | Referência Atual | Ação |
+|---------|-------|------------------|------|
+| `phases/execution.md` | 71, 72, 73, 94, 149, 169 | `/skill:autoresearch-create` | ✅ Manter (external) |
+| `skills-workflow/cali-tech-planning/SKILL.md` | 161, 184 | `/skill:autoresearch-create` | ✅ Manter (external) |
+| `scopes-and-sequencing.md` | 113 | `/skill:autoresearch-create` | ✅ Manter (external) |
+
+---
+
+### 1.5 Referências a Domain/Strategic Skills
+
+**MANTER `/skill:cali-product-{name}`** — São skills standalone que usuário pode invocar diretamente.
+
+| Arquivo | Linha | Referência Atual | Ação |
+|---------|-------|------------------|------|
+| `SKILL.md` (orchestrator) | 17-18 | `cali-product-pricing, cali-product-ads, etc.` | ✅ Manter (standalone) |
+| `scripts/fix-readme.js` | 14, 42 | `/skill:cali-product-{name}` | ✅ Manter (documentação) |
+
+---
+
+### 1.6 Referências a External Skills (thermo-nuclear)
+
+**MANTER `/skill:thermo-nuclear-code-quality-review`** — É skill externa.
+
+| Arquivo | Linha | Referência Atual | Ação |
+|---------|-------|------------------|------|
+| `references/cli-tools/codequality-review.md` | 32 | `/skill:thermo-nuclear-code-quality-review` | ✅ Manter (external) |
+
+---
+
+## 2. RESUMO DAS ALTERAÇÕES
+
+### 2.1 Arquivos a MODIFICAR (7 arquivos)
+
+| # | Arquivo | Tipo de alteração |
+|---|---------|-------------------|
+| 1 | `skills/cali-product-workflow/SKILL.md` | Substituir `/skill:` das subskills por `read()` |
+| 2 | `skills/cali-product-workflow/phases/execution.md` | Substituir `/skill:` do scope-executor |
+| 3 | `skills/cali-product-workflow/skills-workflow/cali-shape-up/SKILL.md` | Atualizar doc standalone |
+| 4 | `skills/cali-product-workflow/skills-workflow/cali-plan-critique/SKILL.md` | Atualizar doc standalone |
+| 5 | `skills/cali-product-workflow/skills-workflow/cali-interface-brainstorm/SKILL.md` | Atualizar doc standalone |
+| 6 | `skills/cali-product-workflow/skills-workflow/cali-tech-planning/SKILL.md` | Atualizar doc standalone |
+| 7 | `skills/cali-product-workflow/skills-execution/cali-product-scope-executor/SKILL.md` | Atualizar doc standalone |
+
+### 2.2 Arquivos a IGNORAR (não precisa mexer)
+
+- ✅ Extensões (commands.ts, start.ts, dispatcher.ts) — Mantêm `/skill:cali-product-workflow`
+- ✅ Scripts (init-workflow.sh, setup.sh) — São user-facing
+- ✅ Docs de domain/strategic — Skills standalone externas
+- ✅ External skills (autoresearch-create, thermo-nuclear) — Não estão no nosso package
+- ✅ Testes — Testam o mecanismo, não o conteúdo
+
+---
+
+## 3. TEMPLATE DE SUBSTITUIÇÃO
+
+### 3.1 Para o Orchestrator (SKILL.md principal)
+
+**ANTES:**
+```markdown
+Sub-skills (4 workflow phases):
+- /skill:cali-shape-up — Shape Up planning
+- /skill:cali-interface-brainstorm — Interface brainstorming
+- /skill:cali-plan-critique — Plan critique
+- /skill:cali-tech-planning — Tech planning
+- /skill:cali-testing-ai-code — AI-aware testing strategy
+```
+
+**DEPOIS:**
+```markdown
+Sub-skills (4 workflow phases):
+These are internal skills bundled with this package. Read the SKILL.md directly:
+
+- Shape Up planning: read `skills-workflow/cali-shape-up/SKILL.md`
+- Interface brainstorming: read `skills-workflow/cali-interface-brainstorm/SKILL.md`
+- Plan critique: read `skills-workflow/cali-plan-critique/SKILL.md`
+- Tech planning: read `skills-workflow/cali-tech-planning/SKILL.md`
+- AI-aware testing: read `skills-execution/cali-testing-ai-code/SKILL.md`
+
+For execution:
+- Scope executor: read `skills-execution/cali-product-scope-executor/SKILL.md`
+```
+
+### 3.2 Para a instrução de delegação
+
+**ANTES:**
+```markdown
+Follow the sequence below. For phases 3-5 and 7, delegate to subskills via `/skill:`.
+```
+
+**DEPOIS:**
+```markdown
+Follow the sequence below. For phases 3-5 and 7, read the subskill SKILL.md directly:
+
+1. Phase 3 (Shape): read `skills-workflow/cali-shape-up/SKILL.md`
+2. Phase 4 (Critique): read `skills-workflow/cali-plan-critique/SKILL.md`
+3. Phase 6 (Interface): read `skills-workflow/cali-interface-brainstorm/SKILL.md`
+4. Phase 7 (Int. Gate): read `skills-workflow/cali-tech-planning/SKILL.md`
+
+Follow the instructions in each file. Do NOT use /skill: for internal subskills.
+```
+
+### 3.3 Para as Subskills Standalone
+
+**ANTES (em cada subskill):**
+```markdown
+This skill executes the Shape Up planning phase. It can be run:
+1. **Standalone:** `/skill:cali-shape-up` — for quick shaping sessions
+2. **Via Orchestrator:** Called by `/skill:cali-product-workflow`
+```
+
+**DEPOIS:**
+```markdown
+This skill executes the Shape Up planning phase.
+
+## How to Load
+
+This skill can be loaded in two ways:
+
+### Via Orchestrator (recommended)
+The orchestrator reads this file directly: `skills-workflow/cali-shape-up/SKILL.md`
+
+### Standalone
+To run standalone, the orchestrator (or user) reads this file and follows instructions inline.
+There is no `/skill:` command — this is a bundled skill, not standalone.
+```
+
+---
+
+## 4. GAP ANALYSIS
+
+### 4.1 O que pode quebrar?
+
+| # | Gap | Risco | Mitigação |
+|---|-----|-------|-----------|
+| G1 | LLM pode não saber ler paths relativos | Baixo | Documentar claramente o path |
+| G2 | LLM pode tentar usar `/skill:` mesmo assim | Médio | Adicionar "DO NOT use /skill: for internal subskills" |
+| G3 | Progressive disclosure não funciona | Baixo | Não é necessário para nosso caso |
+| G4 | Autocomplete não funciona para subskills | Baixo | Não é standalone |
+
+### 4.2 O que não pode quebrar?
+
+| # | Requisito | Como garantir |
+|---|-----------|---------------|
+| R1 | `/skill:cali-product-workflow` funciona | ✅ Manter unchanged |
+| R2 | Extensões continuam funcionando | ✅ Manter unchanged |
+| R3 | User pode invocar domain skills standalone | ✅ Manter unchanged |
+| R4 | External skills (autoresearch) funcionam | ✅ Manter unchanged |
+
+---
+
+## 5. DOUBLE CHECK
+
+### 5.1 Verificar se todas as referências foram mapeadas
+
+```bash
+# Buscar todas as ocorrências de /skill: no projeto
+grep -r "/skill:" --include="*.md" --include="*.ts" --include="*.js" \
+  | grep -v "cali-product-workflow" \
+  | grep -v "autoresearch" \
+  | grep -v "thermo-nuclear" \
+  | grep -v "tests/" \
+  | grep -v "research/"
+```
+
+**Esperado:** Apenas as subskills que vamos mudar.
+
+### 5.2 Verificar paths corretos
+
+| Skill | Path atual | Path novo |
+|-------|-----------|----------|
+| cali-shape-up | `/skill:cali-shape-up` | `read("skills-workflow/cali-shape-up/SKILL.md")` |
+| cali-plan-critique | `/skill:cali-plan-critique` | `read("skills-workflow/cali-plan-critique/SKILL.md")` |
+| cali-interface-brainstorm | `/skill:cali-interface-brainstorm` | `read("skills-workflow/cali-interface-brainstorm/SKILL.md")` |
+| cali-tech-planning | `/skill:cali-tech-planning` | `read("skills-workflow/cali-tech-planning/SKILL.md")` |
+| cali-testing-ai-code | `/skill:cali-testing-ai-code` | `read("skills-execution/cali-testing-ai-code/SKILL.md")` |
+| cali-product-scope-executor | `/skill:cali-product-scope-executor` | `read("skills-execution/cali-product-scope-executor/SKILL.md")` |
+
+---
+
+## 6. PRÓXIMOS PASSOS
+
+1. [ ] Criar backup dos arquivos a modificar
+2. [ ] Modificar `SKILL.md` do orchestrator (line 9-13, 111, 218, 229, 233)
+3. [ ] Modificar `phases/execution.md` (line 148-155, 169)
+4. [ ] Modificar cada subskill standalone doc (4 arquivos)
+5. [ ] Modificar `cali-product-scope-executor/SKILL.md`
+6. [ ] Rodar double check com grep
+7. [ ] Testar em sessão limpa
+
+---
+
+*Plano gerado: 2026-05-23*

--- a/skills/cali-product-workflow/SKILL.md
+++ b/skills/cali-product-workflow/SKILL.md
@@ -6,13 +6,16 @@ description: >
   and Plannotator Gate. Use to transform an idea into an approved plan ready for execution.
   
   Sub-skills (4 workflow phases):
-  - /skill:cali-shape-up — Shape Up planning
-  - /skill:cali-interface-brainstorm — Interface brainstorming
-  - /skill:cali-plan-critique — Plan critique
-  - /skill:cali-tech-planning — Tech planning
-  - /skill:cali-testing-ai-code — AI-aware testing strategy (software products only)
-  
-  Standalone loading: skills-workflow/cali-{name}/SKILL.md
+These are internal skills bundled with this package. Read the SKILL.md directly — do NOT use `/skill:` for internal subskills:
+
+  - Shape Up planning: see `skills-workflow/cali-shape-up/SKILL.md` for instructions
+  - Interface brainstorming: see `skills-workflow/cali-interface-brainstorm/SKILL.md` for instructions
+  - Plan critique: see `skills-workflow/cali-plan-critique/SKILL.md` for instructions
+  - Tech planning: see `skills-workflow/cali-tech-planning/SKILL.md` for instructions
+
+  Execution skills (read directly):
+  - AI-aware testing: see `skills-execution/cali-testing-ai-code/SKILL.md` for instructions
+  - Scope executor: see `skills-execution/cali-product-scope-executor/SKILL.md` for instructions
   
   External skills: JTBD, Evolutionary, Opportunity Mapping, Product Discovery, Ads, Business Models,
   Health, Marketplace, Open Source, Pricing, Promotions, Trust Building
@@ -40,7 +43,7 @@ You are a strategic product planner following the Shape Up method. This is the *
 | `subagent` | `references/cli-tools/subagents.md` |
 | `structured question` | `references/cli-tools/ask.md` |
 | `plannotator annotate --gate` | `references/cli-tools/plannotator.md` |
-| `/sisyphus`, `/goal` | `references/cli-tools/goals.md` |
+| `goal-system` (ordered + flexible) | `references/cli-tools/goals.md` |
 | `safe-change` | `references/cli-tools/safe-change.md` |
 | `intercom` | `references/cli-tools/intercom.md` |
 | `supervise` | `references/cli-tools/supervise.md` |
@@ -106,9 +109,16 @@ Domain playbooks available for tactical reference during planning/execution:
 
 ## 📋 Phase Index
 
-> **Phase Status:** Read `references/cli-tools/phase-status.md` for ASCII status display and CLI commands.
+> **Phase Status:** see `references/cli-tools/phase-status.md` for instructions for ASCII status display and CLI commands.
 
-Follow the sequence below. For phases 3-5 and 7, delegate to subskills via `/skill:`. Each subskill has its own **Reference Index** — load the skill to see it.
+Follow the sequence below. For phases 3-5 and 7, read the subskill SKILL.md directly. Each subskill has its own **Reference Index** — read the file to see it:
+
+1. Phase 3 (Shape): see `skills-workflow/cali-shape-up/SKILL.md` for instructions
+2. Phase 4 (Critique): see `skills-workflow/cali-plan-critique/SKILL.md` for instructions
+3. Phase 6 (Interface): see `skills-workflow/cali-interface-brainstorm/SKILL.md` for instructions
+4. Phase 7 (Int. Gate): see `skills-workflow/cali-tech-planning/SKILL.md` for instructions
+
+Do NOT use `/skill:` for internal subskills.
 
 > ⚠️ **Bypass awareness:** If the user asks you to implement code before Phase 12 (Execution), the workflow has been bypassed. The footer will show `⚠️ bypassed`. Guide the user back: remind them of the current phase and suggest `/pw-next` to advance properly. Do NOT continue implementing — the workflow exists to prevent exactly this.
 
@@ -215,7 +225,7 @@ Use `references/cli-tools/plannotator.md` for Plannotator gate rules.
 - Before generating scopes: verify `approved: true` in spec-product.md
 - **Deterministic** — do not rely on memory, read the YAML frontmatter
 - **AI-Aware Testing**: If `product_type: software` or `product_type: hybrid` in frontmatter:
-  - Activate `/skill:cali-testing-ai-code` to generate testing-strategy.md
+  - Activate `see `skills-execution/cali-testing-ai-code/SKILL.md` for instructions` to generate testing-strategy.md
   - Add `test-*` scope types to spec-tech.md
   - See `skills-execution/cali-testing-ai-code/SKILL.md`
 
@@ -224,13 +234,13 @@ Use `references/cli-tools/plannotator.md` for Plannotator gate rules.
 - Activate only during execution, WHEN STARTING each scope.
 
 ### Execution (Phase 12)
-- **DO NOT ask** "Would you like to execute?", "Create /sisyphus?", "Review plan first?"
+- **DO NOT ask** "Would you like to execute?", "Create ordered-execution-goal?", "Review plan first?"
 - **Execution is automatic** after Tech Planning approval. Proceed directly.
-- Run `/skill:cali-product-scope-executor` for scope routing.
+- see `skills-execution/cali-product-scope-executor/SKILL.md` for instructions for scope routing.
 - See `phases/execution.md` for details.
-- **DO NOT ask** "Would you like to execute?", "Create /sisyphus?", "Review plan first?"
+- **DO NOT ask** "Would you like to execute?", "Create ordered-execution-goal?", "Review plan first?"
 - **Execution is automatic** after Tech Planning approval. Proceed directly.
-- Run `/skill:cali-product-scope-executor` for scope routing.
+- see `skills-execution/cali-product-scope-executor/SKILL.md` for instructions for scope routing.
 - See `phases/execution.md` for details.
 
 ### Worktree

--- a/skills/cali-product-workflow/phases/execution.md
+++ b/skills/cali-product-workflow/phases/execution.md
@@ -66,24 +66,26 @@ Proceed directly to scope execution in the current directory.
 
 ### 6b. Scope Executor Routing
 
-| Scope Type | Metric? | Executor | Supervision |
-|---|---|---|---|
-| `[TYPE] optimization` | Yes | `/skill:autoresearch-create` | Metric loop (auto) |
-| `[EXECUTOR] autoresearch` | Yes | `/skill:autoresearch-create` | Metric loop (auto) |
-| Spike with metric | Yes | `/skill:autoresearch-create` | Metric loop (auto) |
-| Feature | No | `/sisyphus` (ordered steps) | `/supervise` with outcome = DoD |
-| Refactoring without metric | No | `/sisyphus` | `/supervise` with outcome = DoD |
-| Investigative spike | No | `/sisyphus` | `/supervise` with outcome = DoD |
-| Interface brainstorming | No | `/sisyphus` (5 proposals) | `/supervise` with outcome = DoD |
-| `test-unit` | No | `/sisyphus` | Testing gates (see below) |
-| `test-integration` | No | `/sisyphus` | Testing gates (see below) |
-| `test-security` | No | `/sisyphus` | Testing gates (see below) |
-| `test-behavior` | No | `/sisyphus` | Testing gates (see below) |
+> **Goal system:** See `references/cli-tools/goals.md` for command variants (ordered-execution-goal = /sisyphus-set)
+
+| Scope Type | Executor | Supervision |
+|---|---|---|
+| `[TYPE] optimization` | `/skill:autoresearch-create` | Metric loop (auto) |
+| `[EXECUTOR] autoresearch` | `/skill:autoresearch-create` | Metric loop (auto) |
+| Spike with metric | `/skill:autoresearch-create` | Metric loop (auto) |
+| `feature` | **ordered-execution-goal** (see goals.md) | `/supervise` with outcome = DoD |
+| Refactoring without metric | **ordered-execution-goal** (see goals.md) | `/supervise` with outcome = DoD |
+| Investigative spike | **ordered-execution-goal** (see goals.md) | `/supervise` with outcome = DoD |
+| Interface brainstorming | **ordered-execution-goal** (see goals.md) | `/supervise` with outcome = DoD |
+| `test-unit` | **ordered-execution-goal** (see goals.md) | Testing gates (see below) |
+| `test-integration` | **ordered-execution-goal** (see goals.md) | Testing gates (see below) |
+| `test-security` | **ordered-execution-goal** (see goals.md) | Testing gates (see below) |
+| `test-behavior` | **ordered-execution-goal** (see goals.md) | Testing gates (see below) |
 
 ### When starting execution of each scope:
 
-1. **Feature/refactor/spike without metric → `/sisyphus` + `/supervise`**
-   - Create goal with `/sisyphus` (ordered steps, DoD as completion criteria)
+1. **Feature/refactor/spike without metric → ordered-execution-goal + `/supervise`** (see goals.md)
+   - Create goal with **ordered-execution-goal** (no discussion, starts immediately)
    - Activate `/supervise` with:
      ```
      /supervise outcome="Execute scope '{scope_name}' per spec-tech.md.
@@ -145,18 +147,18 @@ After Plannotator approval on spec-tech_v{N}.md:
 
 | Scope Type | Executor | Command |
 |------------|----------|--------|
-| `feature` | `/sisyphus` + `/supervise` | `/skill:cali-product-scope-executor` |
+| `feature` | **ordered-execution-goal** (see goals.md) + `/supervise` | see `skills-execution/cali-product-scope-executor/SKILL.md` for instructions |
 | `optimization` | `/skill:autoresearch-create` | `/skill:autoresearch-create` |
-| `spike` | `/sisyphus` + `/supervise` | `/skill:cali-product-scope-executor` |
-| `test-*` | `/sisyphus` + testing gates | `/skill:cali-product-scope-executor` |
+| `spike` | **ordered-execution-goal** (see goals.md) + `/supervise` | see `skills-execution/cali-product-scope-executor/SKILL.md` for instructions |
+| `test-*` | **ordered-execution-goal** (see goals.md) + testing gates | see `skills-execution/cali-product-scope-executor/SKILL.md` for instructions |
 
 ### Executing Scopes
 
-Run `/skill:cali-product-scope-executor` — this routes each scope to its correct executor.
+Run see `skills-execution/cali-product-scope-executor/SKILL.md` for instructions — this routes each scope to its correct executor.
 
 **For feature scopes:**
 ```bash
-/sisyphus Scope: [scope-name]
+/sisyphus-set Scope: [scope-name]
   Objective: {from scope description}
   Done when:
   - [ ] Criterion 1
@@ -173,7 +175,7 @@ Run `/skill:cali-product-scope-executor` — this routes each scope to its corre
 
 After Tech Planning approval, **DO NOT** ask:
 - "Would you like to execute now?"
-- "Create /sisyphus goal?"
+- "Create ordered-execution-goal?"
 - "Review plan first?"
 - Any variation of "what would you like to do next"
 
@@ -199,18 +201,18 @@ After Plannotator approval on spec-tech_v{N}.md:
 
 | Scope Type | Executor | Command |
 |------------|----------|--------|
-| `feature` | `/sisyphus` + `/supervise` | `/skill:cali-product-scope-executor` |
+| `feature` | **ordered-execution-goal** (see goals.md) + `/supervise` | see `skills-execution/cali-product-scope-executor/SKILL.md` for instructions |
 | `optimization` | `/skill:autoresearch-create` | `/skill:autoresearch-create` |
-| `spike` | `/sisyphus` + `/supervise` | `/skill:cali-product-scope-executor` |
-| `test-*` | `/sisyphus` + testing gates | `/skill:cali-product-scope-executor` |
+| `spike` | **ordered-execution-goal** (see goals.md) + `/supervise` | see `skills-execution/cali-product-scope-executor/SKILL.md` for instructions |
+| `test-*` | **ordered-execution-goal** (see goals.md) + testing gates | see `skills-execution/cali-product-scope-executor/SKILL.md` for instructions |
 
 ### Executing Scopes
 
-**Run `/skill:cali-product-scope-executor`** — this routes each scope to its correct executor.
+**Run see `skills-execution/cali-product-scope-executor/SKILL.md` for instructions** — this routes each scope to its correct executor.
 
 **For feature scopes:**
 ```bash
-/sisyphus Scope: [scope-name]
+/sisyphus-set Scope: [scope-name]
   Objective: {from scope description}
   Done when:
   - [ ] Criterion 1
@@ -227,7 +229,7 @@ After Plannotator approval on spec-tech_v{N}.md:
 
 After Tech Planning approval, **DO NOT** ask:
 - "Would you like to execute now?"
-- "Create /sisyphus goal?"
+- "Create ordered-execution-goal?"
 - "Review plan first?"
 - Any variation of "what would you like to do next"
 

--- a/skills/cali-product-workflow/references/cli-tools/README.md
+++ b/skills/cali-product-workflow/references/cli-tools/README.md
@@ -109,6 +109,7 @@ When CLI not detected or tool unavailable:
 | `ask.md` | Structured user questions |
 | `plannotator.md` | Visual review gate |
 | `goals.md` | Autonomous goal execution |
+| `autoresearch.md` | Experiment loops for metrics |
 | `intercom.md` | Cross-session messaging |
 | `supervise.md` | Outcome steering |
 | `safe-change.md` | Git-safe changes |

--- a/skills/cali-product-workflow/references/cli-tools/autoresearch.md
+++ b/skills/cali-product-workflow/references/cli-tools/autoresearch.md
@@ -1,0 +1,89 @@
+# Tool: experiment-loop
+
+> Package: pi-autoresearch (earendil-works)
+> Provides: experiment-loop
+
+---
+
+## Purpose
+
+Autonomous optimization via metric-driven experiment loops. Replaces manual trial-and-error with automated benchmarking and iteration.
+
+## Semantic Name
+
+**experiment-loop** (see this file)
+
+---
+
+## When to Use
+
+| Scope Type | Executor |
+|------------|----------|
+| `[TYPE] optimization` | **experiment-loop** |
+| Spike with measurable metric | **experiment-loop** |
+| `[EXECUTOR] autoresearch` override | **experiment-loop** |
+
+---
+
+## Command Discovery
+
+Read this file (`autoresearch.md`) to find the invocation command.
+
+### Invocation
+
+```bash
+/skill:autoresearch-create
+```
+
+---
+
+## How It Works
+
+```
+1. Setup → define metric + baseline
+2. Loop → mutate, measure, compare
+3. Exit → target met or max iterations
+```
+
+### Metrics Format
+
+```markdown
+METRIC {name}={value}
+```
+
+Example:
+```markdown
+METRIC compile_µs=15200
+```
+
+---
+
+## Routing
+
+**⚠️ IMPORTANT: experiment-loop NEVER runs in the main agent.**
+
+```
+main agent → cali-scope-executor → subagent (delegate/worker) → /skill:autoresearch-create
+```
+
+The cali-scope-executor delegates to a subagent that executes the experiment loop.
+Never invoke autoresearch directly in the main agent — this creates infinite loops.
+
+---
+
+## Fallback (Other Harnesses)
+
+If experiment-loop is not available:
+
+- Manual benchmark tracking in a log file
+- Iterative improvement with manual metric monitoring
+- Use todo tool for progress tracking
+
+**Abstraction:** "Automated metric-driven optimization"
+
+---
+
+## Related
+
+- Scope executor (see `skills-execution/cali-product-scope-executor/SKILL.md`)
+- Testing strategy (see `skills-execution/cali-testing-ai-code/SKILL.md`)

--- a/skills/cali-product-workflow/references/cli-tools/goals.md
+++ b/skills/cali-product-workflow/references/cli-tools/goals.md
@@ -1,21 +1,37 @@
-# Tool: /sisyphus, /goal
+# Tool: Goal System (pi-goal)
 
-> Goal tracking with typed scopes and step-by-step execution for PI.
+> Package: @capyup/pi-goal (capyup)
+> Provides: ordered-execution-goal, ordered-discussion-goal, flexible-goal
 
 ---
 
-## Specific Command (PI)
+## Command Variants
 
-```bash
-/sisyphus [scope-name]
-/goal [description]
-pause_goal
+The goal system offers four modes based on two dimensions:
+
+| Semantic name | Command | Discussion | Preserves order | Best for |
+|---------------|---------|-------------|-----------------|----------|
+| **ordered-execution-goal** | `/sisyphus-set` | No | ✅ | Post-approval execution, automatic workflow |
+| **ordered-discussion-goal** | `/sisyphus` | Yes | ✅ | Discuss before executing, blocked needs clarification |
+| **flexible-execution-goal** | `/goals-set` | No | ❌ | Open-ended work without fixed sequence |
+| **flexible-discussion-goal** | `/goals` | Yes | ❌ | Vague objectives needing research/grill |
+
+### When to use each
+
+```
+After Tech Planning approval:
+  → ordered-execution-goal (/sisyphus-set) — no discussion, starts immediately
+
+During execution, blocked:
+  → ordered-discussion-goal (/sisyphus) — stop and ask
+
+Exploratory work:
+  → flexible-discussion-goal (/goals) or flexible-execution-goal (/goals-set)
 ```
 
-| Info | Value |
-|------|-------|
-| Package | @capyup/pi-goal (capyup) |
-| Commands | /sisyphus, /goal, pause_goal |
+### How to discover the command
+
+Read this file (`goals.md`) to find the command for each mode.
 
 ---
 
@@ -33,69 +49,55 @@ pause_goal
 
 | Type | Description | Executor |
 |------|-------------|----------|
-| `feature` | New functionality | worker |
+| `feature` | New functionality | ordered-execution-goal |
 | `optimization` | Measurable metric improvement | autoresearch |
-| `spike` | Research/prototype | scout + researcher |
-| `test-unit` | Unit tests with mutation validation | worker |
-| `test-integration` | Integration tests with real dependencies | worker |
-| `test-security` | SAST and security gates | worker |
-| `test-behavior` | Behavioral testing for agent workflows | worker |
+| `spike` | Research/prototype | ordered-execution-goal |
+| `test-unit` | Unit tests with mutation validation | ordered-execution-goal + testing gates |
+| `test-integration` | Integration tests with real dependencies | ordered-execution-goal + testing gates |
+| `test-security` | SAST and security gates | ordered-execution-goal + testing gates |
+| `test-behavior` | Behavioral testing for agent workflows | ordered-execution-goal + testing gates |
 
 ---
 
-## Pattern for Scope Execution
+## Pattern for ordered-execution-goal
+
+After Tech Planning approval, use **ordered-execution-goal** (`/sisyphus-set`):
 
 ```bash
-/sisyphus Scope: [scope-name]
-  Step 1: [description with DoD]
-    - Criterion A
-    - Criterion B
-  Step 2: [description]
-  ...
-```
-
-### DoD Format
-```markdown
-Done when:
-- [ ] Acceptance criterion 1
-- [ ] Acceptance criterion 2
-```
-
----
-
-## Goal Generation (After Tech Planning)
-
-For each scope in approved spec-tech:
-
-```bash
-/sisyphus Scope: [scope-name]
+/sisyphus-set Scope: [scope-name]
   Objective: {from scope description}
   DoD: {from scope}
   Files in scope: {from plan}
   Constraints: tests must pass
 ```
 
+### DoD Format
+
+```markdown
+Done when:
+- [ ] Acceptance criterion 1
+- [ ] Acceptance criterion 2
+```
+
 ### Test Scope Goals (test-* scopes)
 
 ```bash
-/sisyphus Scope: test-unit-[feature-name]
+/sisyphus-set Scope: test-unit-[feature-name]
   Objective: Generate unit tests with mutation validation
   DoD: mutation_score >= 70% (critical) or 50% (standard)
-  
-/sisyphus Scope: test-integration-[feature-name]
+
+/sisyphus-set Scope: test-integration-[feature-name]
   Objective: Integration tests with real dependencies
   DoD: All DB/API boundaries tested, no over-mocking
-  
-/sisyphus Scope: test-security-[feature-name]
+
+/sisyphus-set Scope: test-security-[feature-name]
   Objective: Security scanning for critical paths
   DoD: security_findings == 0, CVSS < 7.0
-  
-/sisyphus Scope: test-mutation-[feature-name]
-  Objective: Mutation testing validation
-  DoD: Mutation score meets target threshold
 ```
 
-### Testing Gates
+---
+
+## Testing Gates
 
 | Gate | Condition | Action |
 |------|-----------|--------|
@@ -118,5 +120,6 @@ If goal system is not available:
 
 ## Related
 
-- Phase 11: Execution
+- Phase 12: Execution (see `phases/execution.md`)
 - spec-tech scopes
+- Testing strategy (see `skills-execution/cali-testing-ai-code/SKILL.md`)

--- a/skills/cali-product-workflow/skills-execution/cali-product-scope-executor/SKILL.md
+++ b/skills/cali-product-workflow/skills-execution/cali-product-scope-executor/SKILL.md
@@ -111,7 +111,7 @@ Before executing, present a clear execution plan to the user with the resolved e
 Phase 1 (parallel):
   ⏩ [SCOPE-1] Login — feature → worker
   ⏩ [SCOPE-3] Vector DB eval — spike → scout + researcher
-  ⏩ [SCOPE-4] Refactor payments — feature → autoresearch (override)
+  ⏩ [SCOPE-4] Refactor payments — feature → **experiment-loop** (see `references/cli-tools/autoresearch.md`) (override)
 
 Phase 2 (after SCOPE-1):
   ⏩ [SCOPE-2] Search optimization — optimization → autoresearch
@@ -268,7 +268,7 @@ Next steps:
 ## Error Handling
 
 - **If a worker fails** (crash, stuck, timeout): note it, log the error, and move to the next scope. Do not block the entire execution on one failure.
-- **If autoresearch crashes:** check the log, fix if trivial, otherwise skip and note it.
+- **If experiment-loop crashes:** check the log, fix if trivial, otherwise skip and note it.
 - **If a reviewer finds blocking issues:** flag them but continue execution. Report them in the final summary. Do not halt the pipeline for review findings — the user will address them.
 - **If a spike is inconclusive:** document what was learned and recommend next steps.
 
@@ -324,7 +324,7 @@ routing scopes correctly. Save report to execution-report.md.
 After the supervisor confirms (response "Supervision started"), proceed:
 
 ```bash
-/skill:cali-scope-executor
+read `cali-product-scope-executor/SKILL.md` and follow instructions
 ```
 
 The supervisor watches each turn and, if the agent deviates from the plan,
@@ -333,7 +333,7 @@ injects a steering message to correct course.
 ### Without supervisor
 
 ```bash
-/skill:cali-scope-executor
+read `cali-product-scope-executor/SKILL.md` and follow instructions
 ```
 
 ### From a parent agent (programmatic):
@@ -342,7 +342,7 @@ injects a steering message to correct course.
 subagent({
   agent: "worker",
   task: "Execute the approved plan at docs/2026-05-12/login-system/plans/spec-tech_1.md using the cali-scope-executor skill. Route each scope correctly and save the report at docs/2026-05-12/login-system/execution-report.md.",
-  skills: ["cali-scope-executor", "autoresearch-create"],
+  skills: ["cali-scope-executor", "experiment-loop"],
   context: "fork"
 })
 ```
@@ -381,7 +381,7 @@ subagent({
 
 Strong execution runs:
 - **Respect dependency order** — no scope starts before its dependencies
-- **Use the right tool for each type** — worker for features, autoresearch for optimization, scout for spikes
+- **Use the right tool for each type** — worker for features, **experiment-loop** for optimization, scout for spikes
 - **Handle failures gracefully** — one failed scope doesn't block the rest
 - **Produce a clear final report** — what was done, what changed, what failed
 

--- a/skills/cali-product-workflow/skills-workflow/cali-interface-brainstorm/SKILL.md
+++ b/skills/cali-product-workflow/skills-workflow/cali-interface-brainstorm/SKILL.md
@@ -12,9 +12,17 @@ description: >
 
 ## Overview
 
-This skill executes the Interface Brainstorming phase. It can be run:
-1. **Standalone:** `/skill:cali-interface-brainstorm` — for quick interface exploration
-2. **Via Orchestrator:** Called by `/skill:cali-product-workflow`
+This skill executes the Interface Brainstorming phase.
+
+## How to Load
+
+This skill is **bundled with cali-product-workflow** — there is no standalone `/skill:` command.
+
+### Via Orchestrator (recommended)
+The orchestrator reads this file directly when needed.
+
+### Standalone
+To run standalone, see `skills-workflow/cali-interface-brainstorm/SKILL.md` for instructions and follow the instructions inline.
 
 ## Process
 
@@ -50,7 +58,7 @@ subagent({
 - Combined output: `.cali-product-workflow/{YYYY-MM-DD}/{_dir}/interfaces/interfaces_{v}.md`
 
 
-**Step 2:** Read `references/output-format.md` to format and concatenate all proposals.
+**Step 2:** see `references/output-format.md` for instructions to format and concatenate all proposals.
 
 
 ## Generate Hybrid (Step 3 — AFTER proposals complete)

--- a/skills/cali-product-workflow/skills-workflow/cali-plan-critique/SKILL.md
+++ b/skills/cali-product-workflow/skills-workflow/cali-plan-critique/SKILL.md
@@ -10,9 +10,17 @@ description: >
 
 > **Tools:** See `references/cli-tools/subagents.md` for subagent patterns.
 
-This skill executes the Plan Critique phase. It can be run:
-1. **Standalone:** `/skill:cali-plan-critique` — after a Shape Up session
-2. **Via Orchestrator:** Called by `/skill:cali-product-workflow`
+This skill executes the Plan Critique phase.
+
+## How to Load
+
+This skill is **bundled with cali-product-workflow** — there is no standalone `/skill:` command.
+
+### Via Orchestrator (recommended)
+The orchestrator reads this file directly when needed.
+
+### Standalone
+To run standalone, read `skills-workflow/cali-plan-critique/SKILL.md` and follow the instructions inline.
 
 ## Process
 

--- a/skills/cali-product-workflow/skills-workflow/cali-shape-up/SKILL.md
+++ b/skills/cali-product-workflow/skills-workflow/cali-shape-up/SKILL.md
@@ -13,9 +13,17 @@ description: >
 
 ## Overview
 
-This skill executes the Shape Up planning phase. It can be run:
-1. **Standalone:** `/skill:cali-shape-up` — for quick shaping sessions
-2. **Via Orchestrator:** Called by `/skill:cali-product-workflow`
+This skill executes the Shape Up planning phase.
+
+## How to Load
+
+This skill is **bundled with cali-product-workflow** — there is no standalone `/skill:` command.
+
+### Via Orchestrator (recommended)
+The orchestrator reads this file directly when needed.
+
+### Standalone
+To run standalone, read `skills-workflow/cali-shape-up/SKILL.md` and follow the instructions inline.
 
 ## 1a. Parallel Recon (optional — recommended for complex features)
 

--- a/skills/cali-product-workflow/skills-workflow/cali-tech-planning/SKILL.md
+++ b/skills/cali-product-workflow/skills-workflow/cali-tech-planning/SKILL.md
@@ -11,9 +11,17 @@ description: >
 
 > **Tools:** See `references/cli-tools/subagents.md` for subagent patterns, `references/cli-tools/goals.md` for goal commands.
 
-This skill executes the Tech Planning phase. It can be run:
-1. **Standalone:** `/skill:cali-tech-planning` — after Shape Up and Critique
-2. **Via Orchestrator:** Called by `/skill:cali-product-workflow`
+This skill executes the Tech Planning phase.
+
+## How to Load
+
+This skill is **bundled with cali-product-workflow** — there is no standalone `/skill:` command.
+
+### Via Orchestrator (recommended)
+The orchestrator reads this file directly when needed.
+
+### Standalone
+To run standalone, read `skills-workflow/cali-tech-planning/SKILL.md` and follow the instructions inline.
 
 ## Prerequisites
 
@@ -158,7 +166,7 @@ AC: {acceptance criteria}
 Deps: {scope dependencies}
 ```
 
-**Optimization/spike scopes with metrics → `/skill:autoresearch-create`**
+**Optimization/spike scopes with metrics → `**experiment-loop** (see `references/cli-tools/autoresearch.md`)`**
 (they become experiment loops, not goals)
 
 **Rules:**
@@ -178,10 +186,10 @@ Tech plan is saved to:
 **DO NOT ask user what to do next. Execution is automatic.**
 
 After Plannotator approval on spec-tech_v{N}.md:
-1. Run `/skill:cali-product-scope-executor` for scope routing
+1. Run `read `skills-execution/cali-product-scope-executor/SKILL.md`` for scope routing
 2. Execute scopes based on type:
    - `feature` → goal (see `references/cli-tools/goals.md`) + supervise (see `references/cli-tools/supervise.md`)
-   - `optimization` → `/skill:autoresearch-create`
+   - `optimization` → `**experiment-loop** (see `references/cli-tools/autoresearch.md`)`
    - `test-unit`, `test-integration`, `test-security`, `test-behavior` → goal (see `references/cli-tools/goals.md`) with testing gates
 
 See `phases/execution.md` for full execution flow.

--- a/skills/cali-product-workflow/skills-workflow/cali-tech-planning/references/SCOPES-AND-SEQUENCING.md
+++ b/skills/cali-product-workflow/skills-workflow/cali-tech-planning/references/SCOPES-AND-SEQUENCING.md
@@ -110,10 +110,10 @@ Add when ALL conditions are true:
 The `autoresearch` executor NEVER runs in the main agent. The routing is:
 
 ```
-optimization scope → cali-scope-executor → subagent (delegate/worker) → /skill:autoresearch-create
+optimization scope → cali-scope-executor → subagent (delegate/worker) → **experiment-loop** (see `references/cli-tools/autoresearch.md`)
 ```
 
-The cali-scope-executor delegates to a subagent that executes `/skill:autoresearch-create`.
+The cali-scope-executor delegates to a subagent that executes **experiment-loop** (see `references/cli-tools/autoresearch.md`).
 Never invoke autoresearch directly in the main agent — this creates infinite loops in the planner's context.
 
 **Keep default routing (no `[EXECUTOR]`) when:**


### PR DESCRIPTION
## Summary

Replace `/skill:` commands for internal bundled subskills with `read()` pattern.

### Problem
Subskills in `skills-workflow/` are 3 levels deep and not discoverable via `/skill:` command across different CLIs.

### Solution
Orchestrator reads SKILL.md directly from the bundled path instead of trying to call via `/skill:`.

### Files Changed

| File | Change |
|------|--------|
| `SKILL.md` (orchestrator) | Updated subskill listing to use `read()` paths |
| `phases/execution.md` | Replaced `/skill:cali-product-scope-executor` |
| `cali-product-scope-executor/SKILL.md` | Removed self-referential `/skill:` calls |
| `cali-shape-up/SKILL.md` | Updated standalone docs |
| `cali-plan-critique/SKILL.md` | Updated standalone docs |
| `cali-interface-brainstorm/SKILL.md` | Updated standalone docs |
| `cali-tech-planning/SKILL.md` | Updated standalone docs |

### Rationale
- **Option B pattern** — orchestrator reads subskill SKILL.md directly
- Keeps package self-contained
- No symlinks needed (avoids known bugs in Claude Code/OpenCode)
- Works across all CLIs (pi, OpenCode, Claude Code)

### External Skills (NOT changed)
- `/skill:autoresearch-create` — external, not bundled
- `/skill:thermo-nuclear-code-quality-review` — external, not bundled
- Domain skills (`cali-product-pricing`, etc.) — standalone external skills