### PR TITLE
fix: portable lock TTL + test backdating for macOS CI

### DIFF
--- a/scripts/stelow
+++ b/scripts/stelow
@@ -118,10 +118,12 @@ PY
 
 # --- lock (mkdir, TTL) -------------------------------------------------------
 
-# Portable directory mtime (seconds) for the lock TTL: `stat -f %m` is BSD/macOS,
-# `stat -c %Y` is GNU. Falls back to "now" (no staleness) if stat is unavailable.
+# Portable directory mtime (seconds) for the lock TTL. Unlike `date`/`stat`,
+# python3's st_mtime is identical on GNU/Linux and BSD/macOS (the script
+# already requires python3 for YAML parsing). Falls back to "now" (no
+# staleness) on error.
 lock_mtime() {
-  stat -f %m "$LOCKDIR" 2>/dev/null || stat -c %Y "$LOCKDIR" 2>/dev/null || echo "$(date +%s)"
+  python3 -c 'import os, sys; print(int(os.stat(sys.argv[1]).st_mtime))' "$LOCKDIR" 2>/dev/null || echo "$(date +%s)"
 }
 
 lock_state() {

--- a/scripts/stelow
+++ b/scripts/stelow
@@ -118,11 +118,17 @@ PY
 
 # --- lock (mkdir, TTL) -------------------------------------------------------
 
+# Portable directory mtime (seconds) for the lock TTL: `stat -f %m` is BSD/macOS,
+# `stat -c %Y` is GNU. Falls back to "now" (no staleness) if stat is unavailable.
+lock_mtime() {
+  stat -f %m "$LOCKDIR" 2>/dev/null || stat -c %Y "$LOCKDIR" 2>/dev/null || echo "$(date +%s)"
+}
+
 lock_state() {
   if [ -d "$LOCKDIR" ]; then
     local now mtime age
     now=$(date +%s)
-    mtime=$(stat -c %Y "$LOCKDIR" 2>/dev/null || echo "$now")
+    mtime=$(lock_mtime)
     age=$((now - mtime))
     if [ "$age" -gt "$LOCK_TTL_SEC" ]; then
       echo "stale (age=${age}s > ttl=${LOCK_TTL_SEC}s)"
@@ -141,19 +147,19 @@ lock_acquire() {
   if mkdir "$LOCKDIR" 2>/dev/null; then
     echo "$$" > "$LOCKDIR/pid"
     hostname > "$LOCKDIR/host"
-    date -Is > "$LOCKDIR/acquired"
+    date -Iseconds > "$LOCKDIR/acquired"
     trap 'rm -rf "$LOCKDIR" 2>/dev/null || true' EXIT
     return 0
   fi
   local now mtime age pid host
   now=$(date +%s)
-  mtime=$(stat -c %Y "$LOCKDIR" 2>/dev/null || echo "$now")
+  mtime=$(lock_mtime)
   age=$((now - mtime))
   if [ "$age" -gt "$LOCK_TTL_SEC" ]; then
     echo "$PROG: stale lock (age=${age}s) — removing" >&2
     rm -rf "$LOCKDIR" || die "lock remove failed"
     if mkdir "$LOCKDIR" 2>/dev/null; then
-      echo "$$" > "$LOCKDIR/pid"; hostname > "$LOCKDIR/host"; date -Is > "$LOCKDIR/acquired"
+      echo "$$" > "$LOCKDIR/pid"; hostname > "$LOCKDIR/host"; date -Iseconds > "$LOCKDIR/acquired"
       trap 'rm -rf "$LOCKDIR" 2>/dev/null || true' EXIT
       return 0
     fi

--- a/skills/stelow-router/SKILL.md
+++ b/skills/stelow-router/SKILL.md
@@ -59,7 +59,7 @@ scripts/stelow advance "$next"
 
 # 4. Append router Hand-off (audit).
 cat >> "$STELOW_STATE" <<EOF
-## Hand-off (router) — $(date -Is)
+## Hand-off (router) — $(date -Iseconds)
 from        : $current
 to          : $next
 skill loaded: stelow-product-$next

--- a/tests/integration/check-version-coherence.test.ts
+++ b/tests/integration/check-version-coherence.test.ts
@@ -124,7 +124,7 @@ async function buildFixture(opts: FixtureOptions): Promise<Fixture> {
   // 5. optional follow-up commit that mutates `package.json#version`.
   if (opts.followupVersion) {
     await writePackageJson(opts.followupVersion);
-    execFileSync('touch', ['-d', 'now', packageJsonPath], { stdio: 'pipe' });
+    execFileSync('touch', [packageJsonPath], { stdio: 'pipe' });
     execFileSync('git', ['add', 'package.json'], { cwd: workDir, stdio: 'pipe' });
     const body = opts.followupMessage ?? `chore: bump to ${opts.followupVersion}`;
     execFileSync('git', ['commit', '-m', body], { cwd: workDir, stdio: 'pipe' });
@@ -184,7 +184,7 @@ async function runScript(workDir: string, scriptPath: string, args: string[]): P
  */
 async function stagePendingVersionChange(fx: Fixture, version: string): Promise<void> {
   await writeFile(fx.packageJson, JSON.stringify({ name: 'fixture', version }), 'utf8');
-  execFileSync('touch', ['-d', 'now', fx.packageJson], { stdio: 'pipe' });
+  execFileSync('touch', [fx.packageJson], { stdio: 'pipe' });
   execFileSync('git', ['add', 'package.json'], { cwd: fx.workDir, stdio: 'pipe' });
 }
 

--- a/tests/integration/stelow-fs.test.ts
+++ b/tests/integration/stelow-fs.test.ts
@@ -13,7 +13,7 @@
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
 import { execSync, spawnSync, ChildProcess } from "node:child_process";
-import { mkdtempSync, writeFileSync, mkdirSync, readFileSync, rmSync, existsSync, readdirSync } from "node:fs";
+import { mkdtempSync, writeFileSync, mkdirSync, readFileSync, rmSync, existsSync, readdirSync, utimesSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { randomBytes } from "node:crypto";
@@ -64,6 +64,12 @@ stages:
 `);
 }
 
+// Backdate a lock dir's mtime with Node (portable; GNU/BSD `touch -d` differs).
+function backdateLock(wd: Workdir, when: Date): void {
+  const lock = join(wd.dir, ".stelow", "lock");
+  utimesSync(lock, when, when);
+}
+
 function run(wd: Workdir, args: string[], env: Record<string, string> = {}): { status: number; stdout: string; stderr: string } {
   const r = spawnSync("bash", [wd.helper, ...args], {
     cwd: wd.dir, encoding: "utf8",
@@ -93,7 +99,7 @@ describe("parallel-lock contention", () => {
     writeFileSync(join(wd.dir, ".stelow", "lock", "host"), "ghost");
     // make it stale so both will try to clear+reacquire
     const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000);
-    execSync(`touch -d "${fiveMinAgo.toISOString()}" .stelow/lock`, { cwd: wd.dir });
+    backdateLock(wd, fiveMinAgo);
 
     const r1 = run(wd, ["advance", "critique"], { STELOW_LOCK_TTL_SEC: "10" });
     const r2 = run(wd, ["advance", "critique"], { STELOW_LOCK_TTL_SEC: "10" });
@@ -125,7 +131,7 @@ describe("crash-resume", () => {
 
     // backdate the lock to make it stale
     const tenMinAgo = new Date(Date.now() - 10 * 60 * 1000);
-    execSync(`touch -d "${tenMinAgo.toISOString()}" .stelow/lock`, { cwd: wd.dir });
+    backdateLock(wd, tenMinAgo);
 
     // The next advance must: clear the stale lock, succeed, write invariants.
     const r = run(wd, ["advance", "critique"], { STELOW_LOCK_TTL_SEC: "10" });

--- a/tests/unit/stelow-helper.test.ts
+++ b/tests/unit/stelow-helper.test.ts
@@ -14,7 +14,7 @@
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
 import { execSync, spawnSync } from "node:child_process";
-import { mkdtempSync, writeFileSync, mkdirSync, readFileSync, statSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, mkdirSync, readFileSync, statSync, rmSync, utimesSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { randomBytes } from "node:crypto";
@@ -46,6 +46,12 @@ function makeWorkdir(): Workdir {
   const wd = { dir, helper };
   workdirs.push(wd);
   return wd;
+}
+
+// Backdate a lock dir's mtime with Node (portable; GNU/BSD `touch -d` differs).
+function backdateLock(wd: Workdir, when: Date): void {
+  const lock = join(wd.dir, ".stelow", "lock");
+  utimesSync(lock, when, when);
 }
 
 function makeState(wd: Workdir, current_stage: string): void {
@@ -161,7 +167,7 @@ describe("advance", () => {
     writeFileSync(join(wd.dir, ".stelow", "lock", "host"), "test");
     // backdate the lock dir by 5 minutes
     const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000);
-    execSync(`touch -d "${fiveMinAgo.toISOString()}" .stelow/lock`, { cwd: wd.dir });
+    backdateLock(wd, fiveMinAgo);
     const r = run(wd, ["advance", "critique"], { env: { ...process.env, STELOW_LOCK_TTL_SEC: "10" } });
     expect(r.status).toBe(0);
     expect(r.stdout).toContain("advanced to critique");
@@ -201,7 +207,7 @@ describe("doctor", () => {
     mkdirSync(join(wd.dir, ".stelow", "lock"), { recursive: true });
     writeFileSync(join(wd.dir, ".stelow", "lock", "pid"), "1");
     const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000);
-    execSync(`touch -d "${fiveMinAgo.toISOString()}" .stelow/lock`, { cwd: wd.dir });
+    backdateLock(wd, fiveMinAgo);
     const r = run(wd, ["doctor"]);
     expect(r.status).toBe(0); // warn is non-fatal
     expect(r.stdout).toMatch(/warn\s+stale-lock/);


### PR DESCRIPTION
## Problem
CI on `main` has been failing since the skills-only restructure landed. The `Unit Tests (macos-latest)` job fails 11 tests across 4 files, all from GNU-only CLI flags used on BSD/macOS runners:

- `scripts/stelow` used `date -Is` → breaks **every** `advance` (lock acquire) on macOS
- `scripts/stelow` used `stat -c %Y` → silently falls back to age=0 on macOS, defeating stale-lock TTL detection
- tests used `touch -d "<ISO>"` / `touch -d now` → fails on macOS (different `touch` semantics)

## Fix
- `scripts/stelow`: `date -Is` → `date -Iseconds` (valid on GNU + BSD); new `lock_mtime()` handles both `stat -f %m` (BSD) and `stat -c %Y` (GNU)
- tests: backdate lock dirs via `node:fs` `utimesSync` instead of shell `touch -d`
- `check-version-coherence.test.ts`: `touch -d now` → plain `touch`
- `skills/stelow-router/SKILL.md`: align `$(date -Is)` hand-off template

## Verification
- Full suite locally (macOS): 523/523 pass, review → All gates green
- `npm run build`, `typecheck`, `lint`, rigor-scan ≥60 all pass